### PR TITLE
Fix issue where Rails.env is not defined

### DIFF
--- a/lib/better_image_tag/image_tag.rb
+++ b/lib/better_image_tag/image_tag.rb
@@ -152,7 +152,7 @@ module BetterImageTag
     end
 
     def not_compiled?
-      Rails.env.development? || Rails.env.test?
+      !!Rails.application.assets
     end
 
     def enforce_requirements

--- a/lib/better_image_tag/inline_data.rb
+++ b/lib/better_image_tag/inline_data.rb
@@ -69,7 +69,7 @@ module BetterImageTag
     def contents
       @_contents ||= begin
         if image.match?(%r{https?://})
-          open(image).read
+          URI.open(image).read
         elsif local_file?
           File.read(image)
         elsif not_compiled?

--- a/lib/better_image_tag/inline_data.rb
+++ b/lib/better_image_tag/inline_data.rb
@@ -92,7 +92,7 @@ module BetterImageTag
     # rubocop:enable Security/Open
 
     def not_compiled?
-      Rails.env.development? || Rails.env.test?
+      !!Rails.application.assets
     end
 
     def local_file?

--- a/spec/better_image_tag/image_tag_spec.rb
+++ b/spec/better_image_tag/image_tag_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe BetterImageTag::ImageTag do
   let(:view_context) do
     view_paths = ActionController::Base.view_paths
     lookup_context = ActionView::LookupContext.new(view_paths)
-    ActionView::Base.new(lookup_context, {})
+    controller = ApplicationController.new
+    ActionView::Base.new(lookup_context, {}, controller)
   end
 
   before do

--- a/spec/better_image_tag/inline_data_spec.rb
+++ b/spec/better_image_tag/inline_data_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe BetterImageTag::InlineData do
       it 'returns the original image src when ssl error' do
         url = 'http://localhost/nothing.jpg'
         inliner = BetterImageTag::InlineData.new(url)
-        allow(inliner).to receive(:open).and_raise(OpenSSL::SSL::SSLError)
+        allow(URI).to receive(:open).and_raise(OpenSSL::SSL::SSLError)
 
         result = inliner.inline_data
 
@@ -58,7 +58,7 @@ RSpec.describe BetterImageTag::InlineData do
         url = 'http://localhost/nothing.jpg'
         inliner = BetterImageTag::InlineData.new(url)
         error = OpenURI::HTTPError.new 'error', nil
-        allow(inliner).to receive(:open).and_raise(error)
+        allow(URI).to receive(:open).and_raise(error)
 
         result = inliner.inline_data
 

--- a/spec/better_image_tag/picture_tag_spec.rb
+++ b/spec/better_image_tag/picture_tag_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe BetterImageTag::PictureTag do
   let(:view_context) do
     view_paths = ActionController::Base.view_paths
     lookup_context = ActionView::LookupContext.new(view_paths)
-    ActionView::Base.new(lookup_context, {})
+    controller = ApplicationController.new
+    ActionView::Base.new(lookup_context, {}, controller)
   end
 
   before do

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => 'public, max-age=3600'
   }
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
Issue
=====

https://github.com/jayroh/better_image_tag/issues/5

Why?
====

> We are working on pre-compiling assets before running specs, but this
> errors out because better_image_tag checks Rails.env rather than
> checking the existence of Rails.application.assets to see if things are
> compiled.

What?
=====

The predicate method asks one thing but branches into doing something
that is wholly unrelated. Instead, and thanks to @ransombriggs, we
should be checking for presence of the thing we want to work with.